### PR TITLE
CI/CD now embeds version

### DIFF
--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Set version for ldflags (non-tag ref)
         if: "!startsWith(github.ref, 'refs/tags/')"
-        run: echo "LDFLAGS_VERSION=test" >> $GITHUB_ENV
+        run: echo "LDFLAGS_VERSION=development" >> $GITHUB_ENV
 
       - name: Build and push container images/tags
         uses: docker/build-push-action@v2

--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -151,8 +151,7 @@ jobs:
           context: ./controller
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          build-args:
-            - LDFLAGS_VERSION: ${{ env.LDFLAGS_VERSION }}
+          build-args: LDFLAGS_VERSION=${{ env.LDFLAGS_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -72,7 +72,8 @@ jobs:
 
       - name: Set version for ldflags (non-tag ref)
         if: "!startsWith(github.ref, 'refs/tags/')"
-        run: echo "LDFLAGS_VERSION=development" >> $GITHUB_ENV
+        # Makes the embedded version "{branch-name}-development"
+        run: echo "LDFLAGS_VERSION=$(echo ${GITHUB_REF:11})-development" >> $GITHUB_ENV
 
       - name: Build executable
         env:
@@ -143,7 +144,8 @@ jobs:
 
       - name: Set version for ldflags (non-tag ref)
         if: "!startsWith(github.ref, 'refs/tags/')"
-        run: echo "LDFLAGS_VERSION=development" >> $GITHUB_ENV
+        # Makes the embedded version "{branch-name}-development"
+        run: echo "LDFLAGS_VERSION=$(echo ${GITHUB_REF:11})-development" >> $GITHUB_ENV
 
       - name: Build and push container images/tags
         uses: docker/build-push-action@v2

--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -151,7 +151,8 @@ jobs:
           context: ./controller
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          build-args: ["LDFLAGS_VERSION=${{ env.LDFLAGS_VERSION }}"]
+          build-args:
+            - LDFLAGS_VERSION: ${{ env.LDFLAGS_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -66,6 +66,14 @@ jobs:
         if: "!contains(matrix.go-os-arch, 'windows')"
         run: echo "EXEC_SUFFIX=$("")" >> $GITHUB_ENV
 
+      - name: Set version for ldflags (tag ref)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "LDFLAGS_VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
+
+      - name: Set version for ldflags (non-tag ref)
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        run: echo "LDFLAGS_VERSION=development" >> $GITHUB_ENV
+
       - name: Build executable
         env:
           # We aim to be CGO free to improve compatibility. Disabling it in the CI should help with enforcing that goal.
@@ -73,7 +81,7 @@ jobs:
           GOARM: 7
           GOOS: ${{ env.COMP_GOOS }}
           GOARCH: ${{ env.COMP_GOARCH }}
-        run: go build -o encodarr-controller-${{ env.COMP_GOOS }}-${{ env.COMP_GOARCH }}${{ env.EXEC_SUFFIX }}
+        run: go build -o encodarr-controller-${{ env.COMP_GOOS }}-${{ env.COMP_GOARCH }}${{ env.EXEC_SUFFIX }} -ldflags="-X 'github.com/BrenekH/encodarr/controller/config.Version=${{ env.LDFLAGS_VERSION }}'"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
@@ -129,12 +137,21 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set version for ldflags (tag ref)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "LDFLAGS_VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
+
+      - name: Set version for ldflags (non-tag ref)
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        run: echo "LDFLAGS_VERSION=test" >> $GITHUB_ENV
+
       - name: Build and push container images/tags
         uses: docker/build-push-action@v2
         with:
           context: ./controller
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          build-args: ["LDFLAGS_VERSION=${{ env.LDFLAGS_VERSION }}"]
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/runner.yaml
+++ b/.github/workflows/runner.yaml
@@ -67,6 +67,15 @@ jobs:
         if: "!contains(matrix.go-os-arch, 'windows')"
         run: echo "EXEC_SUFFIX=$("")" >> $GITHUB_ENV
 
+      - name: Set version for ldflags (tag ref)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "LDFLAGS_VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
+
+      - name: Set version for ldflags (non-tag ref)
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        # Makes the embedded version "{branch-name}-development"
+        run: echo "LDFLAGS_VERSION=$(echo ${GITHUB_REF:11})-development" >> $GITHUB_ENV
+
       - name: Build executable
         env:
           # We aim to be CGO free to improve compatibility. Disabling it in the CI should help with enforcing that goal.
@@ -130,12 +139,22 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set version for ldflags (tag ref)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "LDFLAGS_VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
+
+      - name: Set version for ldflags (non-tag ref)
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        # Makes the embedded version "{branch-name}-development"
+        run: echo "LDFLAGS_VERSION=$(echo ${GITHUB_REF:11})-development" >> $GITHUB_ENV
+
       - name: Build and push container images/tags
         uses: docker/build-push-action@v2
         with:
           context: ./runner
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          build-args: LDFLAGS_VERSION=${{ env.LDFLAGS_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -3,13 +3,14 @@ FROM golang:1.16-buster AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG LDFLAGS_VERSION=development
 
 WORKDIR /go/src/encodarr/controller
 
 COPY . .
 
-# Disable CGO so that we have a static binary
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o encodarr .
+# Disable CGO so that we have a static binary, set the platform for multi-arch builds, and embed the Version.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o encodarr -ldflags="-X 'github.com/BrenekH/encodarr/controller/config.Version=${LDFLAGS_VERSION}'" .
 
 
 # Run stage

--- a/controller/config/config.go
+++ b/controller/config/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Version represents the current version of the Encodarr Controller
-const Version string = "0.0.1-alpha.1"
+var Version string = "development"
 
 // Settings is used to represent how settings are saved to a file
 type Settings struct {

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -3,13 +3,14 @@ FROM golang:1.16-buster AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG LDFLAGS_VERSION=development
 
 WORKDIR /go/src/encodarr/runner
 
 COPY . .
 
 # Disable CGO so that we have a static binary
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o runner cmd/EncodarrRunner/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o runner -ldflags="-X 'github.com/BrenekH/encodarr/runner/options.Version=${LDFLAGS_VERSION}'" cmd/EncodarrRunner/main.go
 
 
 # Run stage

--- a/runner/options/options.go
+++ b/runner/options/options.go
@@ -12,6 +12,9 @@ import (
 	"github.com/BrenekH/logange"
 )
 
+// Version represents the current version of the Encodarr Runner
+var Version string = "development"
+
 type optionConst struct {
 	EnvVar  string
 	CmdLine string


### PR DESCRIPTION
Now when a binary is built using GitHub Actions, it has the tag of the build embedded directly as the version. If the build is not from a tagged commit, the pattern `<branch name>-development` is used instead.