### PR TITLE
Recreate files table w/ new column name

### DIFF
--- a/controller/sqlite/migrations/000002_pipeline_to_cmd_decider.down.sql
+++ b/controller/sqlite/migrations/000002_pipeline_to_cmd_decider.down.sql
@@ -3,3 +3,11 @@ ALTER TABLE libraries DROP COLUMN cmd_decider_settings;
 ALTER TABLE libraries ADD COLUMN pipeline binary;
 
 ALTER TABLE libraries ADD COLUMN file_cache binary;
+
+DROP TABLE files;
+
+CREATE TABLE IF NOT EXISTS files (
+    path text,
+    modtime timestamp,
+    mediainfo binary
+);

--- a/controller/sqlite/migrations/000002_pipeline_to_cmd_decider.up.sql
+++ b/controller/sqlite/migrations/000002_pipeline_to_cmd_decider.up.sql
@@ -3,3 +3,11 @@ ALTER TABLE libraries DROP COLUMN pipeline;
 ALTER TABLE libraries ADD COLUMN cmd_decider_settings text DEFAULT '';
 
 ALTER TABLE libraries DROP COLUMN file_cache;
+
+DROP TABLE files;
+
+CREATE TABLE IF NOT EXISTS files (
+    path text,
+    modtime timestamp,
+    metadata binary
+);


### PR DESCRIPTION
Changes the DB migrations to ensure that the files table is recreated with `metadata` as a column name instead of `mediainfo`.  The column can't just be renamed because the binary data format is different between 0.2.x and 0.3.x.

Fixes #111 