### PR TITLE
Add UNIQUE constraint to files.path

### DIFF
--- a/controller/sqlite/migrations/000001_init_schema.up.sql
+++ b/controller/sqlite/migrations/000001_init_schema.up.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS libraries (
 );
 
 CREATE TABLE IF NOT EXISTS files (
-    path text,
+    path text UNIQUE,
     modtime timestamp,
     mediainfo binary
 );


### PR DESCRIPTION
Fixes #112 by adding a `UNIQUE` constraint to the `path` field in the `files` table. This likely was left out when the move to `golang-migrate` happened and this change adds it back in.

Unfortunately, databases will need to be recreated if they were generated after 0.3.0.