### PR TITLE
chore: update to go 1.17

### DIFF
--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -8,8 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-latest']
-        go-version: ['1.16']
+        os: ["ubuntu-latest"]
+        go-version: ["1.17"]
 
     defaults:
       run:
@@ -35,9 +35,17 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-latest']
-        go-version: ['1.16']
-        go-os-arch: ['linux/amd64', 'linux/arm64', 'linux/arm', 'windows/amd64', 'darwin/amd64', 'darwin/arm64']
+        os: ["ubuntu-latest"]
+        go-version: ["1.17"]
+        go-os-arch:
+          [
+            "linux/amd64",
+            "linux/arm64",
+            "linux/arm",
+            "windows/amd64",
+            "darwin/amd64",
+            "darwin/arm64",
+          ]
 
     defaults:
       run:

--- a/.github/workflows/runner.yaml
+++ b/.github/workflows/runner.yaml
@@ -8,8 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-latest']
-        go-version: ['1.16']
+        os: ["ubuntu-latest"]
+        go-version: ["1.17"]
 
     defaults:
       run:
@@ -36,9 +36,17 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-latest']
-        go-version: ['1.16']
-        go-os-arch: ['linux/amd64', 'linux/arm64', 'linux/arm', 'windows/amd64', 'darwin/amd64', 'darwin/arm64']
+        os: ["ubuntu-latest"]
+        go-version: ["1.17"]
+        go-os-arch:
+          [
+            "linux/amd64",
+            "linux/arm64",
+            "linux/arm",
+            "windows/amd64",
+            "darwin/amd64",
+            "darwin/arm64",
+          ]
 
     defaults:
       run:

--- a/.gitignore
+++ b/.gitignore
@@ -6,142 +6,12 @@
 **/*.avi
 **/*.m4v
 
-# Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode
-# Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode
+# Executables
+controller/cmd/main
+runner/cmd/EncodarrRunner/main
 
-### Python ###
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-pip-wheel-metadata/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-.python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode
 
 ### VisualStudioCode ###
 .vscode/*
@@ -151,8 +21,41 @@ dmypy.json
 !.vscode/extensions.json
 *.code-workspace
 
+# Local History for Visual Studio Code
+.history/
+
 ### VisualStudioCode Patch ###
 # Ignore all local history of files
 .history
+.ionide
 
-# End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode
+# Support for Project snippet scope
+!.vscode/*.code-snippets
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
+
+# Created by https://www.toptal.com/developers/gitignore/api/go
+# Edit at https://www.toptal.com/developers/gitignore?templates=go
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+# End of https://www.toptal.com/developers/gitignore/api/go

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.16-buster AS builder
+FROM golang:1.17-buster AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -12,18 +12,19 @@ COPY . .
 # Disable CGO so that we have a static binary, set the platform for multi-arch builds, and embed the Version into globals.Version.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o encodarr -ldflags="-X 'github.com/BrenekH/encodarr/controller/globals.Version=${LDFLAGS_VERSION}'" cmd/main.go
 
-
 # Run stage
 FROM ubuntu:20.04
 
 ENV TZ=Etc/GMT \
-ENCODARR_CONFIG_DIR="/config"
+  ENCODARR_CONFIG_DIR="/config"
 
 WORKDIR /usr/src/app
 
 RUN chmod 777 /usr/src/app \
- && apt-get update -qq \
- && DEBIAN_FRONTEND="noninteractive" apt-get install -qq -y tzdata mediainfo
+  && apt-get update -qq \
+  && DEBIAN_FRONTEND="noninteractive" apt-get install -qq -y --no-install-recommends tzdata mediainfo \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/src/encodarr/controller/encodarr ./encodarr
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.16-buster AS builder
+FROM golang:1.17-buster AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -12,18 +12,19 @@ COPY . .
 # Disable CGO so that we have a static binary
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o runner -ldflags="-X 'github.com/BrenekH/encodarr/runner/options.Version=${LDFLAGS_VERSION}'" cmd/EncodarrRunner/main.go
 
-
 # Run stage
 FROM ubuntu:20.04
 
 ENV TZ=Etc/GMT \
-ENCODARR_CONFIG_DIR="/config"
+  ENCODARR_CONFIG_DIR="/config"
 
 WORKDIR /usr/src/app
 
 RUN chmod 777 /usr/src/app \
- && apt-get update -qq \
- && DEBIAN_FRONTEND="noninteractive" apt-get install -qq -y tzdata ffmpeg
+  && apt-get update -qq \
+  && DEBIAN_FRONTEND="noninteractive" apt-get install -qq -y --no-install-recommends tzdata ffmpeg \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/src/encodarr/runner/runner ./runner
 


### PR DESCRIPTION
- update docker images to use go 1.17
- improve docker images with suggestions from hadolint
- update GitHub workflow files to use go 1.17
- update `.gitignore` to ignore go specific files instead of python

Closes https://github.com/BrenekH/encodarr/issues/130